### PR TITLE
Avoided encoding error

### DIFF
--- a/te.py
+++ b/te.py
@@ -303,7 +303,7 @@ def main(path, rarity_set, team_page=False, out=False):
     i += 1
 
   try:
-    file = io.open(JSON_OUTPUT_PATH_PREFIX + os.path.basename(path) + ".out", 'w')
+    file = io.open(JSON_OUTPUT_PATH_PREFIX + os.path.basename(path) + ".out", 'w', encoding = "utf-8")
     file.write(file_output)
     file.close()
   except BaseException:


### PR DESCRIPTION
Avoided encoding error like `UnicodeEncodeError: 'ascii' codec can't encode character '\u3000' in position 2: ordinal not in range(128)` by specifying explicit encoding for output file.